### PR TITLE
implements git clone with https and added respective log support

### DIFF
--- a/cmd/gitr/clone.go
+++ b/cmd/gitr/clone.go
@@ -23,6 +23,10 @@ func cloneHandler(cmd *cobra.Command, args []string) {
 		log.Fatalf("clone url required as argument")
 	}
 	inputUrl := args[0]
+	var token = ""
+	if len(args) > 1 {
+		token = args[1]
+	}
 	dry, err := cmd.InheritedFlags().GetBool(string(cli.Dry))
 	cli.HandleFlagErr(err, cli.Dry)
 	creDir, err := cmd.PersistentFlags().GetBool(string(cli.CreDir))
@@ -31,7 +35,7 @@ func cloneHandler(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("failed to get gitr config. err: %v", err)
 	}
-	if err := clone.Clone(cfg, inputUrl, creDir, dry); err != nil {
+	if err := clone.Clone(cfg, inputUrl, token, creDir, dry); err != nil {
 		log.Fatalf("failed to clone repo. err: %v", err)
 	}
 }


### PR DESCRIPTION
* git clone with https only for gitlab/hub.
* it requires a personal access token to clone using https.
   * it will be a one time configuration.
   * necessary logs are added for support of user.
   * once configured, personal access token will be stored in root folder in laptop and that will be used from next time.